### PR TITLE
Add tx error related interface

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -228,6 +228,9 @@
 * [Banner Commands](#banner-commands)
   * [Banner config commands](#banner-config-commands)
   * [Banner show command](#banner-show-command)
+* [Tx error counter commands](#tx-error-counter-commands)
+  * [Tx error counter config commands](#tx-error-counter-config-commands)
+  * [Tx error counter show command](#tx-error-counter-show-command)
 
 ## Document History
 
@@ -13907,4 +13910,40 @@ enabled  Login    You are on
                   All access and/or use are subject to monitoring.
 
                   Help:    https://sonic-net.github.io/SONiC/
+```
+
+# Tx error counter commands
+
+This sub-section explains the list of the configuration options available for tx error counter feature.
+When tx error count exceed threshold, then it will set interface status to not OK.
+
+## Tx error counter config commands
+
+- Config tx error count threshold to 10 times
+
+```
+admin@sonic:~$ sudo config interface tx-error-threshold set Ethernet0 10
+```
+
+- Clear tx error count threshold to 10 times
+
+```
+admin@sonic:~$ sudo config interface tx-error-threshold set Ethernet0 10
+```
+
+- Set tx error stat poll period to 10 seconds
+
+```
+admin@sonic:~$ sudo config tx-error-stat-poll-period 10
+```
+
+## Tx error counter show command
+
+- Show current tx error counters and interface status
+
+```
+admin@sonic:~$ show interfaces tx_error Ethernet0
+Port       status      tx_error_stat
+---------  --------  ---------------
+Ethernet0  OK                      0
 ```

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -890,17 +890,16 @@ def tx_error(interfacename):
     table = []
     for k in txerr_keys:
         k = k.replace(prefix_statedb, "")
-        r = []
-        r.append(k)
+        if k == interfacename:
+            r = [k]
+            r.append(state_db.get(state_db.STATE_DB, prefix_statedb + k, "tx_status"))
+            entry = appl_db.get_all(appl_db.APPL_DB, prefix_appldb + k)
+            if 'tx_error_stat' not in entry:
+                r.append("")
+            else:
+                r.append(entry['tx_error_stat'])
 
-        r.append(state_db.get(state_db.STATE_DB, prefix_statedb + k, "tx_status"))
-        entry = appl_db.get_all(appl_db.APPL_DB, prefix_appldb + k)
-        if 'tx_error_stat' not in entry:
-            r.append("")
-        else:
-            r.append(entry['tx_error_stat'])
-
-        table.append(r)
+            table.append(r)
 
     header = ['Port', 'status', 'tx_error_stat']
     click.echo(tabulate(table, header))

--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -870,6 +870,41 @@ def fec_status(interfacename, namespace, display, verbose):
 
     clicommon.run_command(cmd, display_cmd=verbose)
 
+@interfaces.command("tx_error")
+@click.argument('interfacename', required=True)
+def tx_error(interfacename):
+    """Show Interface tx_error information"""
+
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)   # Make one attempt only
+    TABLE_NAME_SEPARATOR = '|'
+    prefix_statedb = "TX_ERR_STATE|"
+    _hash = '{}{}'.format(prefix_statedb, '*')
+    # DBInterface keys() method
+    txerr_keys = state_db.keys(state_db.STATE_DB, _hash)
+    appl_db = SonicV2Connector(host='127.0.0.1')
+    appl_db.connect(appl_db.APPL_DB, False)
+    prefix_appldb = "TX_ERR_APPL:"
+    _hash = '{}{}'.format(prefix_appldb, "*")
+    txerr_appl_keys = appl_db.keys(appl_db.APPL_DB, _hash)
+    table = []
+    for k in txerr_keys:
+        k = k.replace(prefix_statedb, "")
+        r = []
+        r.append(k)
+
+        r.append(state_db.get(state_db.STATE_DB, prefix_statedb + k, "tx_status"))
+        entry = appl_db.get_all(appl_db.APPL_DB, prefix_appldb + k)
+        if 'tx_error_stat' not in entry:
+            r.append("")
+        else:
+            r.append(entry['tx_error_stat'])
+
+        table.append(r)
+
+    header = ['Port', 'status', 'tx_error_stat']
+    click.echo(tabulate(table, header))
+
 #
 # switchport group (show interfaces switchport ...)
 #

--- a/tests/config_int_tx_test.py
+++ b/tests/config_int_tx_test.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import pytest
+import mock
+from importlib import reload
+
+from click.testing import CliRunner
+
+from utilities_common.db import Db
+
+modules_path = os.path.join(os.path.dirname(__file__), "..")
+test_path = os.path.join(modules_path, "tests")
+sys.path.insert(0, modules_path)
+sys.path.insert(0, test_path)
+mock_db_path = os.path.join(test_path, "int_tx_input")
+
+class TestIntTx(object):
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(cls):
+        print("SETUP")
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+        import config.main as config
+        reload(config)
+        yield
+        print("TEARDOWN")
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        from .mock_tables import dbconnector
+        dbconnector.dedicated_dbs = {}
+
+    def test_interface_tx_error_threshold_clear(
+            self,
+            get_cmd_module):
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+        from .mock_tables import dbconnector
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
+
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        # set a new threshold
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["tx-error-threshold"].commands["clear"],
+                                   ["Ethernet0"], obj=obj)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0
+
+    def test_interface_tx_error_threshold_set(
+            self,
+            get_cmd_module):
+        (config, show) = get_cmd_module
+        jsonfile_config = os.path.join(mock_db_path, "config_db.json")
+        from .mock_tables import dbconnector
+        dbconnector.dedicated_dbs['CONFIG_DB'] = jsonfile_config
+
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db': db.cfgdb}
+
+        # set a new threshold
+        with mock.patch('utilities_common.cli.run_command') as mock_run_command:
+            result = runner.invoke(config.config.commands["interface"].commands["tx-error-threshold"].commands["set"],
+                                   ["Ethernet0", "10"], obj=obj)
+            print(result.exit_code, result.output)
+            assert result.exit_code == 0

--- a/tests/int_tx_input/config_db.json
+++ b/tests/int_tx_input/config_db.json
@@ -1,0 +1,51 @@
+{
+    "INTERFACE|Ethernet16": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet16|192.168.10.1/24": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet2": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet2|192.168.0.1/24": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet4": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet4|192.168.4.1/24": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet4|192.168.100.1/24": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet8": {
+        "NULL": "NULL"
+    },
+    "INTERFACE|Ethernet8|192.168.3.1/24": {
+        "NULL": "NULL"
+    },
+    "PORTCHANNEL_INTERFACE|PortChannel2": {
+        "NULL": "NULL"
+    },
+    "PORTCHANNEL_INTERFACE|PortChannel2|10.0.0.56/31": {
+        "NULL": "NULL"
+    },
+    "VLAN_INTERFACE|Vlan2": {
+        "proxy_arp": "enabled"
+    },
+    "VLAN_INTERFACE|Vlan2|192.168.1.1/21": {
+        "NULL": "NULL"
+    },
+    "VLAN_SUB_INTERFACE|Ethernet16.16": {
+        "admin_status": "up"
+    },
+    "VLAN_SUB_INTERFACE|Ethernet16.16|16.1.1.1/16": {
+        "NULL": "NULL"
+    },
+    "TX_ERR_CFG|Ethernet0": {
+        "tx_error_check_period": 1,
+        "tx_error_threshold": 10
+    }
+}

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -263,10 +263,15 @@ PortChannel0004  routed
 PortChannel1001  trunk               4000
 """
 
-show_intf_tx_error = """\
+show_intf_tx_error_ok = """\
 Port       status      tx_error_stat
 ---------  --------  ---------------
 Ethernet0  OK                      0
+"""
+
+show_intf_tx_error_notok = """\
+Port       status      tx_error_stat
+---------  --------  ---------------
 Ethernet1  NotOK                  11
 """
 
@@ -502,23 +507,21 @@ class TestInterfaces(object):
         assert result.exit_code == 0
         assert result.output == show_interfaces_switchport_config_in_alias_mode_output
 
-    def test_show_intf_tx_error(self):
+    def test_show_intf_tx_error_ok(self):
         runner = CliRunner()
-        # print("Available commands in show.cli:")
-        # print(show.cli.commands)
-
-        # if "interfaces" in show.cli.commands:
-        #     print("Commands under 'interfaces':")
-        #     print(show.cli.commands["interfaces"].commands)
-
-        # if "tx_error" in show.cli.commands["interfaces"].commands:
-        #     print("Commands under 'tx_error':")
-        #     print(show.cli.commands["interfaces"].commands["tx_error"])
         result = runner.invoke(show.cli.commands["interfaces"].commands["tx_error"], ["Ethernet0"])
         print(result.exit_code)
         print(result.output)
         assert result.exit_code == 0
-        assert result.output == show_intf_tx_error
+        assert result.output == show_intf_tx_error_ok
+
+    def test_show_intf_tx_error_notok(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["interfaces"].commands["tx_error"], ["Ethernet1"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_intf_tx_error_notok
 
     @classmethod
     def teardown_class(cls):

--- a/tests/interfaces_test.py
+++ b/tests/interfaces_test.py
@@ -263,6 +263,12 @@ PortChannel0004  routed
 PortChannel1001  trunk               4000
 """
 
+show_intf_tx_error = """\
+Port       status      tx_error_stat
+---------  --------  ---------------
+Ethernet0  OK                      0
+Ethernet1  NotOK                  11
+"""
 
 class TestInterfaces(object):
     @classmethod
@@ -495,6 +501,24 @@ class TestInterfaces(object):
 
         assert result.exit_code == 0
         assert result.output == show_interfaces_switchport_config_in_alias_mode_output
+
+    def test_show_intf_tx_error(self):
+        runner = CliRunner()
+        # print("Available commands in show.cli:")
+        # print(show.cli.commands)
+
+        # if "interfaces" in show.cli.commands:
+        #     print("Commands under 'interfaces':")
+        #     print(show.cli.commands["interfaces"].commands)
+
+        # if "tx_error" in show.cli.commands["interfaces"].commands:
+        #     print("Commands under 'tx_error':")
+        #     print(show.cli.commands["interfaces"].commands["tx_error"])
+        result = runner.invoke(show.cli.commands["interfaces"].commands["tx_error"], ["Ethernet0"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_intf_tx_error
 
     @classmethod
     def teardown_class(cls):

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -409,5 +409,11 @@
         "action": "set_vrf",
         "param/vrf_id": "p4rt-vrf-80",
         "controller_metadata": "my metadata"
+    },
+    "TX_ERR_APPL:Ethernet0": {
+        "tx_error_stat": "0"
+    },
+    "TX_ERR_APPL:Ethernet1": {
+        "tx_error_stat": "11"
     }
 }

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1684,5 +1684,11 @@
     },
     "STP_TABLE|GLOBAL": {
         "max_stp_inst": "510"
+    },
+    "TX_ERR_STATE|Ethernet0" : {
+        "tx_status": "OK"
+    },
+    "TX_ERR_STATE|Ethernet1" : {
+        "tx_status": "NotOK"
     }
 }


### PR DESCRIPTION
#### Note, this PR has dependency on:
https://github.com/jianyuewu/sonic-swss/pull/1
https://github.com/jianyuewu/sonic-swss-common/pull/1

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
Add tx error counters for each interfaces.

#### What I did
In current scenario, we need some tx error counters to indicate there is some issue happen.
Newly added commands are:
1. config interface tx-error-threshold set Ethernet0 10
Set the tx error threshold to 10 for interface Ethernet0. If the increase in transmission errors is less than 10 compared to the last measurement, then the interface status should remain configured as OK. If the increase exceeds 10, then the status should be configured as NotOK.

2. config interface tx-error-threshold clear Ethernet0
Clear the tx error threshold field, so this feature will be disabled.

3. config tx-error-stat-poll-period 10
Configure the polling period for tx error statistics to 10 seconds. This means that the system will check or update the tx error statistics at intervals of 10 seconds.

4. show interfaces tx_error Ethernet0
Show Ethernet0's tx error counter.

#### How I did it
Add subcommand in config and show interfaces logics.

#### How to verify it
Run those command in SONiC switch, and verify by unit tests.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
$ sudo config interface tx-error-threshold set Ethernet0 10
$ sudo config interface tx-error-threshold clear Ethernet0
$ sudo config tx-error-stat-poll-period 10
$ show interfaces tx_error Ethernet0
Port       status      tx_error_stat
---------  --------  ---------------
Ethernet0  OK                      0

#### Details if related
No need to merge to sonic-net/sonic-utilities: master, only for studying purposes