### PR TITLE
[config] Exit when config qos reload fail

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9636,6 +9636,7 @@ Some of the example QOS configurations that users can modify are given below.
 
   In this example, it uses the buffers.json.j2 file and qos.json.j2 file from platform specific folders.
   When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
+  When an error occurs, such as "Operation not completed successfully, please save and reload configuration," the system will record the status, and exit with code 1 after executing all the commands.
   ```
 
 **config qos reload --ports port_list**

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1607,6 +1607,16 @@ class TestConfigQos(object):
         _clear_qos(True, False)
         _wait_until_clear.assert_called_with(['BUFFER_*_TABLE:*', 'BUFFER_*_SET'], interval=0.5, timeout=0, verbose=False)
 
+    def test_qos_wait_until_clear_not_empty_should_exit(self):
+        from config.main import _wait_until_clear
+
+        with mock.patch('swsscommon.swsscommon.SonicV2Connector.keys', side_effect=self._keys), \
+            mock.patch('sys.exit') as mock_exit:
+            TestConfigQos._keys_counter = 10
+            # timeout set to 0, so will always timeout, to trigger sys.exit(1)
+            _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5, 0, verbose=False)
+            self.assertEqual(config.main.WAIT_UNTIL_CLEAR_STATUS, 1)
+
     def test_qos_reload_single(
             self, get_cmd_module, setup_qos_mock_apis,
             setup_single_broadcom_asic


### PR DESCRIPTION
Fix issue where 'config qos reload' returns exit code 0, when operation unsuccessful, now it will call sys.exit(1).

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When config qos reload failed with error print "Operation not completed successfully", exit with code 1.

#### How I did it
Add sys.exit(1) when error reported.

#### How to verify it
Test with command "config qos reload".

#### Previous command output (if the output of a command-line utility has changed)
root@qa-sys-eth-5640-rfc:/home/admin# config qos reload
Operation not completed successfully, please save and reload configuration.
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Buffer calculation model updated, restarting swss is required to take effect

#### New command output (if the output of a command-line utility has changed)
root@qa-sys-eth-5640-rfc:/home/admin# config qos reload
Operation not completed successfully, please save and reload configuration.
Note that latter /usr/local/bin/sonic-cfggen won't be called, as error happen in earlier phase, and they are not needed.
