### PR TITLE
[config] Exit with non-zero when qos reload fail

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -125,6 +125,7 @@ TTL_RANGE = click.IntRange(min=0, max=255)
 QUEUE_RANGE = click.IntRange(min=0, max=255)
 GRE_TYPE_RANGE = click.IntRange(min=0, max=65535)
 ADHOC_VALIDATION = True
+WAIT_UNTIL_CLEAR_STATUS = 0
 
 if os.environ.get("UTILITIES_UNIT_TESTING", "0") in ("1", "2"):
     temp_system_reload_lockfile = tempfile.NamedTemporaryFile()
@@ -778,6 +779,7 @@ def storm_control_delete_entry(port_name, storm_type):
 
 
 def _wait_until_clear(tables, interval=0.5, timeout=30, verbose=False):
+    global WAIT_UNTIL_CLEAR_STATUS
     start = time.time()
     empty = False
     app_db = SonicV2Connector(host='127.0.0.1')
@@ -795,6 +797,7 @@ def _wait_until_clear(tables, interval=0.5, timeout=30, verbose=False):
         empty = (non_empty_table_count == 0)
     if not empty:
         click.echo("Operation not completed successfully, please save and reload configuration.")
+        WAIT_UNTIL_CLEAR_STATUS = 1
     return empty
 
 
@@ -3161,6 +3164,8 @@ def _update_buffer_calculation_model(config_db, model):
     help="Dry run, writes config to the given file"
 )
 def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports, verbose):
+    global WAIT_UNTIL_CLEAR_STATUS
+    WAIT_UNTIL_CLEAR_STATUS = 0
     """Reload QoS configuration"""
     if ports:
         log.log_info("'qos reload --ports {}' executing...".format(ports))
@@ -3227,18 +3232,23 @@ def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports, verbose)
                     '-t', '{},{}'.format(qos_template_file, qos_fname),
                     '-y', sonic_version_file
                 ]
-                clicommon.run_command(command, display_cmd=True)
+                out, rc = clicommon.run_command(command, display_cmd=True, return_cmd=True)
+                if rc != 0:
+                    click.echo("Command failed due to rc value!")
+                    # clicommon.run_command does this by default when rc != 0 and return_cmd=False
+                    sys.exit(rc)
 
                 command = [SONIC_CFGGEN_PATH] + cmd_ns + ["-j", buffer_fname, "-j", qos_fname]
                 if dry_run:
                     out, rc = clicommon.run_command(command + ["--print-data"], display_cmd=True, return_cmd=True)
-                    if rc != 0:
-                        # clicommon.run_command does this by default when rc != 0 and return_cmd=False
-                        sys.exit(rc)
                     with open("{}{}".format(dry_run, asic_id_suffix), 'w') as f:
                         json.dump(json.loads(out), f, sort_keys=True, indent=4)
                 else:
-                    clicommon.run_command(command + ["--write-to-db"], display_cmd=True)
+                    out, rc = clicommon.run_command(command + ["--write-to-db"], display_cmd=True, return_cmd=True)
+                if rc != 0:
+                    click.echo("Command failed due to rc value!")
+                    # clicommon.run_command does this by default when rc != 0 and return_cmd=False
+                    sys.exit(rc)
 
             else:
                 click.secho("QoS definition template not found at {}".format(
@@ -3251,6 +3261,10 @@ def reload(ctx, no_dynamic_buffer, no_delay, dry_run, json_data, ports, verbose)
 
     if buffer_model_updated:
         print("Buffer calculation model updated, restarting swss is required to take effect")
+
+    if WAIT_UNTIL_CLEAR_STATUS != 0:
+        click.echo("Command failed due to _wait_until_clear() failed!")
+        sys.exit(1)
 
 def _qos_update_ports(ctx, ports, dry_run, json_data):
     """Reload QoS configuration"""

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9636,6 +9636,7 @@ Some of the example QOS configurations that users can modify are given below.
 
   In this example, it uses the buffers.json.j2 file and qos.json.j2 file from platform specific folders.
   When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
+  When an error occurs, such as "Operation not completed successfully, please save and reload configuration," the system will record the status, and exit with code 1 after executing all the commands.
   ```
 
 **config qos reload --ports port_list**

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1607,6 +1607,16 @@ class TestConfigQos(object):
         _clear_qos(True, False)
         _wait_until_clear.assert_called_with(['BUFFER_*_TABLE:*', 'BUFFER_*_SET'], interval=0.5, timeout=0, verbose=False)
 
+    def test_qos_wait_until_clear_not_empty_should_exit(self):
+        from config.main import _wait_until_clear
+
+        with mock.patch('swsscommon.swsscommon.SonicV2Connector.keys', side_effect=self._keys), \
+            mock.patch('sys.exit') as mock_exit:
+            TestConfigQos._keys_counter = 10
+            # timeout set to 0, so will always timeout, to set WAIT_UNTIL_CLEAR_STATUS as 1
+            _wait_until_clear(["BUFFER_POOL_TABLE:*"], 0.5, 0, verbose=False)
+            self.assertEqual(config.main.WAIT_UNTIL_CLEAR_STATUS, 1)
+
     def test_qos_reload_single(
             self, get_cmd_module, setup_qos_mock_apis,
             setup_single_broadcom_asic


### PR DESCRIPTION
Fix issue where 'config qos reload' returns exit code 0, when operation unsuccessful, now it return 1 after executing all the commands.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When config qos reload failed with error print "Operation not completed successfully", exit with code 1 finally, instead of exit with code 0.

#### How I did it
Add WAIT_UNTIL_CLEAR_STATUS flag in function _wait_until_clear() when error reported, and after execute command finish, check this flag, if it is none zero, then exit 1.

#### How to verify it
Test with command "config qos reload". Note that "config load_minigraph" is also verified, not impacted.

#### Previous command output (if the output of a command-line utility has changed)
# config qos reload
Operation not completed successfully, please save and reload configuration.
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Buffer calculation model updated, restarting swss is required to take effect

#### New command output (if the output of a command-line utility has changed)
# config qos reload
Operation not completed successfully, please save and reload configuration.
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Buffer calculation model updated, restarting swss is required to take effect
Command failed due to _wait_until_clear() failed!
