### PR TITLE
[config] Exit with non-zero when qos reload fail

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9636,6 +9636,7 @@ Some of the example QOS configurations that users can modify are given below.
 
   In this example, it uses the buffers.json.j2 file and qos.json.j2 file from platform specific folders.
   When there are no changes in the platform specific configutation files, they internally use the file "/usr/share/sonic/templates/buffers_config.j2" and "/usr/share/sonic/templates/qos_config.j2" to generate the configuration.
+  When an error occurs, such as "Operation not completed successfully, please save and reload configuration," the system will record the status, after executing all the latter commands, exit with code 1.
   ```
 
 **config qos reload --ports port_list**


### PR DESCRIPTION
Fix issue where 'config qos reload' returns exit code 0, when operation unsuccessful, now it return 1 after executing all the commands.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
When config qos reload failed with error print "Operation not completed successfully", exit with code 1 finally, instead of exit with code 0.

#### How I did it
Add WAIT_UNTIL_CLEAR_STATUS flag in function _wait_until_clear() when error reported, and after execute command finish, check this flag, if it is none zero, then exit 1.

#### How to verify it
Test with command "config qos reload". Note that "config load_minigraph" is also verified, not impacted.

#### Previous command output (if the output of a command-line utility has changed)
```bash
# config qos reload
Operation not completed successfully, please save and reload configuration.
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Buffer calculation model updated, restarting swss is required to take effect
```
#### New command output (if the output of a command-line utility has changed)
```bash
# config qos reload
Operation not completed successfully, please save and reload configuration.
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_dynamic.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Buffer calculation model updated, restarting swss is required to take effect
# echo $?
1
```

