### PR TITLE
[decode-syseeprom] optimize startup performance with lazy imports

### DIFF
--- a/scripts/decode-syseeprom
+++ b/scripts/decode-syseeprom
@@ -16,7 +16,6 @@ import re
 import sys
 import errno
 
-import sonic_platform
 from sonic_platform_base.sonic_eeprom.eeprom_tlvinfo import TlvInfoDecoder
 from sonic_py_common import device_info, logger
 from swsscommon.swsscommon import SonicV2Connector
@@ -32,6 +31,7 @@ def instantiate_eeprom_object():
     eeprom = None
 
     try:
+        import sonic_platform
         eeprom = sonic_platform.platform.Platform().get_chassis().get_eeprom()
     except Exception as e:
         log.log_error('Failed to obtain EEPROM object due to {}'.format(repr(e)))

--- a/tests/decode_syseeprom_test.py
+++ b/tests/decode_syseeprom_test.py
@@ -212,3 +212,9 @@ CRC-32               0xFE        4  0xAC518FB3
     def test_support_platforms_no_eeprom(self, mockDbBased, mockNotDbBased):
         ret = decode_syseeprom.main()
         assert ret == errno.ENODEV
+
+    def test_instantiate_eeprom_object(self):
+        """Test instantiate_eeprom_object to cover lazy import of sonic_platform"""
+        eeprom = decode_syseeprom.instantiate_eeprom_object()
+        # Since sonic_platform is mocked, this should return the mocked eeprom object
+        assert eeprom is not None


### PR DESCRIPTION
The background is decode-syseeprom script had slow startup time due to expensive imports at the top level.

#### What I did
1. Moved sonic_platform imports into the function that use it.
2. For the command "show platform syseeprom", sonic_platform is never imported, saving ~200ms.

#### How I did it
Implemented lazy import pattern for sonic_platform.
Because TlvInfoDecoder still need to be used in command "show platform syseeprom", so still keep it.

#### How to verify it
Before lazy import update:
```bash
admin@sonic:~$ time show platform syseeprom
...
real	0m2.064s
user	0m1.242s
sys	0m0.269s
```
After lazy import update:
```bash
admin@sonic:~$ time show platform syseeprom
...
real	0m1.807s
user	0m1.255s
sys	0m0.285s
```
Can save ~200ms.