### PR TITLE
Add filesystem sync after plugin installation

### DIFF
--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -1077,6 +1077,10 @@ class PackageManager:
         for command in SONIC_CLI_COMMANDS:
             self._install_cli_plugin(package, command)
 
+        # Ensure all plugin files are synced to disk after installation
+        # This prevents incomplete/corrupted files after power cycle
+        os.sync()
+
     def _uninstall_cli_plugins(self, package: Package):
         for command in SONIC_CLI_COMMANDS:
             self._uninstall_cli_plugin(package, command)

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -456,6 +456,10 @@ class PackageManager:
         self.database.update_package(package.entry)
         self.database.commit()
 
+        # Ensure all files (plugins, services, database) are synced to disk
+        # This prevents data loss or corruption after power cycle
+        os.sync()
+
     @under_lock
     def update(self,
                name: str,
@@ -546,6 +550,10 @@ class PackageManager:
         package.entry.version = None
         self.database.update_package(package.entry)
         self.database.commit()
+
+        # Ensure database update is synced to disk
+        os.sync()
+
         manifest_path = os.path.join(MANIFESTS_LOCATION, name)
         edit_path = os.path.join(MANIFESTS_LOCATION, name + ".edit")
         if os.path.exists(manifest_path):
@@ -692,6 +700,10 @@ class PackageManager:
         new_package_entry.version = new_version
         self.database.update_package(new_package_entry)
         self.database.commit()
+
+        # Ensure all files are synced to disk after upgrade
+        os.sync()
+
         if update_only:
             manifest_path = os.path.join(MANIFESTS_LOCATION, name)
             edit_path = os.path.join(MANIFESTS_LOCATION, name + ".edit")
@@ -1076,10 +1088,6 @@ class PackageManager:
     def _install_cli_plugins(self, package: Package):
         for command in SONIC_CLI_COMMANDS:
             self._install_cli_plugin(package, command)
-
-        # Ensure all plugin files are synced to disk after installation
-        # This prevents incomplete/corrupted files after power cycle
-        os.sync()
 
     def _uninstall_cli_plugins(self, package: Package):
         for command in SONIC_CLI_COMMANDS:

--- a/tests/sonic_package_manager/test_manager.py
+++ b/tests/sonic_package_manager/test_manager.py
@@ -17,10 +17,13 @@ def mock_run_command():
 
 
 def test_installation_not_installed(package_manager):
-    package_manager.install('test-package')
-    package = package_manager.get_installed_package('test-package')
-    assert package.installed
-    assert package.entry.default_reference == '1.6.0'
+    with patch('sonic_package_manager.manager.os.sync') as mock_sync:
+        package_manager.install('test-package')
+        package = package_manager.get_installed_package('test-package')
+        assert package.installed
+        assert package.entry.default_reference == '1.6.0'
+        # Verify os.sync() is called after installation to ensure data persistence
+        mock_sync.assert_called()
 
 
 def test_installation_already_installed(package_manager):
@@ -179,7 +182,8 @@ def test_installation_multiple_cli_plugin(package_manager, fake_metadata_resolve
     manifest['cli']= {'show': ['/cli/plugin.py', '/cli/plugin2.py']}
     with patch('sonic_package_manager.manager.get_cli_plugin_directory') as get_dir_mock, \
          patch('os.remove') as remove_mock, \
-         patch('os.path.exists') as path_exists_mock:
+         patch('os.path.exists') as path_exists_mock, \
+         patch('sonic_package_manager.manager.os.sync') as mock_sync:
         get_dir_mock.return_value = '/'
         package_manager.install('test-package')
         package_manager.docker.extract.assert_has_calls(
@@ -189,6 +193,9 @@ def test_installation_multiple_cli_plugin(package_manager, fake_metadata_resolve
             ],
             any_order=True,
         )
+        # Verify os.sync() is called after installation
+        install_sync_count = mock_sync.call_count
+        assert install_sync_count >= 1, "os.sync() should be called after installation"
 
         package_manager._set_feature_state = Mock()
         package_manager.uninstall('test-package', force=True)
@@ -199,6 +206,9 @@ def test_installation_multiple_cli_plugin(package_manager, fake_metadata_resolve
             ],
             any_order=True,
         )
+        # Verify os.sync() is called after uninstallation
+        uninstall_sync_count = mock_sync.call_count
+        assert uninstall_sync_count > install_sync_count, "os.sync() should be called after uninstallation"
 
 
 def test_installation_cli_plugin_skipped(package_manager, fake_metadata_resolver, anything):
@@ -328,10 +338,13 @@ def test_manager_upgrade(package_manager, sonic_fs, mock_run_command):
     package_manager.install('test-package-6=1.5.0')
     package = package_manager.get_installed_package('test-package-6')
 
-    package_manager.install('test-package-6=2.0.0')
-    upgraded_package = package_manager.get_installed_package('test-package-6')
-    assert upgraded_package.entry.version == Version.parse('2.0.0')
-    assert upgraded_package.entry.default_reference == package.entry.default_reference
+    with patch('sonic_package_manager.manager.os.sync') as mock_sync:
+        package_manager.install('test-package-6=2.0.0')
+        upgraded_package = package_manager.get_installed_package('test-package-6')
+        assert upgraded_package.entry.version == Version.parse('2.0.0')
+        assert upgraded_package.entry.default_reference == package.entry.default_reference
+        # Verify os.sync() is called after upgrade to ensure data persistence
+        mock_sync.assert_called()
 
     mock_run_command.assert_has_calls(
         [
@@ -627,3 +640,35 @@ def test_installation_from_file_no_tags(package_manager, mock_docker_api, sonic_
     # Get the package from the database and verify the tag was set to the image ID
     package = package_manager.database.get_package('test-package')
     assert package.docker_image_reference == 'Azure/docker-test:1.6.0'
+
+def test_sync_called_after_database_commit(package_manager):
+    """Test that os.sync() is called after database.commit() to ensure transactional consistency"""
+
+    call_order = []
+
+    # Mock both database.commit() and os.sync() to track call order
+    original_commit = package_manager.database.commit
+
+    def mock_commit():
+        call_order.append('commit')
+        original_commit()
+
+    def mock_sync():
+        call_order.append('sync')
+
+    with patch.object(package_manager.database, 'commit', side_effect=mock_commit), \
+         patch('sonic_package_manager.manager.os.sync', side_effect=mock_sync):
+
+        package_manager.install('test-package')
+
+        # Verify that both commit and sync were called
+        assert 'commit' in call_order, "database.commit() should be called"
+        assert 'sync' in call_order, "os.sync() should be called"
+
+        # Find the last commit and verify sync comes after it
+        last_commit_idx = len(call_order) - 1 - call_order[::-1].index('commit')
+        last_sync_idx = len(call_order) - 1 - call_order[::-1].index('sync')
+
+        # sync should be called after the final commit
+        assert last_sync_idx > last_commit_idx, \
+            f"os.sync() should be called after database.commit(), but call order was: {call_order}"


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->
#### Why I did it
In some scenarios, after install plugin then power cycle, file content might lost.
Before power cycle, file size is 205, also can found register function in python file, but after power cycle, this file size is 0, so assume this is caused by page cache didn't write back to disk on time, when power cycle happen.
Before power cycle:
```bash
2026 Feb  3 10:34:16.156531 sonic-testbed INFO  [DIAGNOSTIC] Starting CLI plugins installation for package: cpu-report
2026 Feb  3 10:34:16.157013 sonic-testbed INFO  [DIAGNOSTIC] Installing CLI plugin: package=cpu-report, command=show, src=/show.py, dst=/usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
2026 Feb  3 10:34:16.157177 sonic-testbed INFO  [DIAGNOSTIC] Starting extract: image=sha256:1230c222517c88863253c94dba34a788b580604618373fff24ab737a7d519c3f, src=/show.py, dst=/usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
2026 Feb  3 10:34:16.267834 sonic-testbed INFO  [DIAGNOSTIC] Tar buffer size: 2048 bytes, MD5: b0b48780efda61d230dc2e3592cc3ba6
2026 Feb  3 10:34:16.268709 sonic-testbed INFO  [DIAGNOSTIC] Tar member: name=show.py, size=205, isfile=True
2026 Feb  3 10:34:16.269652 sonic-testbed INFO  [DIAGNOSTIC] File extracted successfully: path=/usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py, size=205, MD5=f2f3ca5258fd0685adf2cc44567934fb, elapsed=0.112s
2026 Feb  3 10:34:16.270313 sonic-testbed INFO  [DIAGNOSTIC] Python syntax validation: PASS for /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
2026 Feb  3 10:34:16.270820 sonic-testbed INFO  [DIAGNOSTIC] Plugin file verification after extract: path=/usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py, size=205, MD5=f2f3ca5258fd0685adf2cc44567934fb, mtime=1684332898.0, extract_time=0.113s
2026 Feb  3 10:34:16.271351 sonic-testbed INFO  [DIAGNOSTIC] Python syntax check: PASS for /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
2026 Feb  3 10:34:16.271638 sonic-testbed INFO  [DIAGNOSTIC] Found "def register" in plugin file: /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
2026 Feb  3 10:34:16.271918 sonic-testbed INFO  [DIAGNOSTIC] Completed CLI plugins installation for package: cpu-report, elapsed=0.115s
```

After power cycle:
```bash
admin@sonic-testbed:~$ show version 2>&1
failed to import plugin show.plugins.cpu-report: module 'show.plugins.cpu-report' has no attribute 'register'

# file size is 0
admin@sonic-testbed:~$ ls -lih /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
830572 -rw-r--r-- 1 root root 0 May 17  2023 /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
# md5sum is different with previous
admin@sonic-testbed:~$ sudo md5sum /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
d41d8cd98f00b204e9800998ecf8427e  /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
# file is empty
admin@sonic-testbed:~$ sudo stat /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
  File: /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
  Size: 0               Blocks: 0          IO Block: 4096   regular empty file
Device: 0,27    Inode: 830572      Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2026-02-03 10:34:16.266593882 +0200
Modify: 2023-05-17 17:14:58.000000000 +0300
Change: 2026-02-03 10:34:16.262593831 +0200
 Birth: 2026-02-03 10:34:16.262593831 +0200
admin@sonic-testbed:~$ cat /usr/local/lib/python3.13/dist-packages/show/plugins/cpu-report.py
admin@sonic-testbed:~$
```

#### What I did
Fix intermittent plugin corruption after power cycle by adding `os.sync()` to flush filesystem buffers after all CLI plugins are installed. This prevents incomplete plugin files that cause `'module has no attribute 'register''` errors in show commands after system reboot.

#### How I did it
Added `os.sync()` system call in `PackageManager._install_cli_plugins()` method after all CLI plugin files are extracted and installed. This ensures that:
1. All plugin file data is flushed from the OS page cache to disk
2. File metadata and data are both persisted before the method returns
3. Plugin files remain intact even if an abrupt power loss occurs shortly after installation

#### How to verify it
1. Install cpu-report package: `sonic-package-manager install cpu-report==1.0.0 -y`
2. Enable feature: `config feature state cpu-report enabled`
3. Upgrade package: `sonic-package-manager install cpu-report==1.0.7 -y`
4. Upgrade again: `sonic-package-manager install cpu-report==1.0.8 -y`
5. Immediately perform power cycle
6. After reboot, run: `show version`
If there is problem, error is: failed to import plugin show.plugins.cpu-report: module 'show.plugins.cpu-report' has no attribute 'register'.