### PR TITLE
sfputil: don't abort eeprom-hexdump on single page read failure

### DIFF
--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -869,20 +869,14 @@ def eeprom_hexdump_pages_general(logical_port_name, pages, target_page):
         if page == 0:
             lines.append(f'{EEPROM_DUMP_INDENT}Lower page 0h')
             return_code, output = eeprom_dump_general(physical_port, page, 0, PAGE_SIZE, 0)
-            if return_code != 0:
-                return return_code, output
             lines.append(output)
 
             lines.append(f'\n{EEPROM_DUMP_INDENT}Upper page 0h')
             return_code, output = eeprom_dump_general(physical_port, page, PAGE_OFFSET, PAGE_SIZE, PAGE_OFFSET)
-            if return_code != 0:
-                return return_code, output
             lines.append(output)
         else:
             lines.append(f'\n{EEPROM_DUMP_INDENT}Upper page {page:x}h')
             return_code, output = eeprom_dump_general(physical_port, page, page * PAGE_SIZE + PAGE_OFFSET, PAGE_SIZE, PAGE_OFFSET)
-            if return_code != 0:
-                return return_code, output
             lines.append(output)
 
     lines.append('') # add a new line
@@ -915,20 +909,14 @@ def eeprom_hexdump_pages_sff8472(logical_port_name, pages, target_page):
                 return_code, output = eeprom_dump_general(physical_port, page, 0, SFF8472_A0_SIZE, 0)
             else:
                 return_code, output = eeprom_dump_general(physical_port, page, 0, PAGE_SIZE, 0)
-            if return_code != 0:
-                return return_code, 'Error: Failed to read EEPROM for A0h!'
             lines.append(output)
         elif page == 1:
             lines.append(f'\n{EEPROM_DUMP_INDENT}A2h dump (lower 128 bytes)')
             return_code, output = eeprom_dump_general(physical_port, page, SFF8472_A0_SIZE, PAGE_SIZE, 0)
-            if return_code != 0:
-                return ERROR_NOT_IMPLEMENTED, 'Error: Failed to read EEPROM for A2h!'
             lines.append(output)
         else:
             lines.append(f'\n{EEPROM_DUMP_INDENT}A2h dump (upper 128 bytes) page {page - 2:x}h')
             return_code, output = eeprom_dump_general(physical_port, page, SFF8472_A0_SIZE + PAGE_OFFSET + page * PAGE_SIZE, PAGE_SIZE, PAGE_SIZE)
-            if return_code != 0:
-                return ERROR_NOT_IMPLEMENTED, 'Error: Failed to read EEPROM for A2h upper page!'
             lines.append(output)
 
     lines.append('') # add a new line

--- a/tests/sfputil_test.py
+++ b/tests/sfputil_test.py
@@ -298,7 +298,7 @@ class TestSfputil(object):
                 Vcc: 3.2577Volts
         ModuleThresholdValues:
 '''
-        ), 
+        ),
         (
             'QSFP-DD Double Density 8X Pluggable Transceiver',
             True,
@@ -1033,15 +1033,11 @@ Ethernet0  N/A
 
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom-hexdump'])
+        # With continue-on-failure behavior: exit 0 and failed pages are reported, not abort
         assert result.exit_code == 0
-        expected_output = """EEPROM hexdump for port Ethernet0
-        Error: Failed to read EEPROM for page 0h, flat_offset 0, page_offset 0, size 128!
-
-EEPROM hexdump for port Ethernet4
-        Error: Failed to read EEPROM for A0h!
-
-"""
-        assert result.output == expected_output
+        assert "EEPROM hexdump for port Ethernet0" in result.output
+        assert "EEPROM hexdump for port Ethernet4" in result.output
+        assert "Error: Failed to read EEPROM" in result.output
 
     @patch('sfputil.main.platform_chassis')
     @patch('sfputil.main.platform_sfputil')
@@ -1159,7 +1155,45 @@ EEPROM hexdump for port Ethernet4
         sfputil.eeprom_hexdump_single_port('Ethernet0', 3)
         mock_dump.assert_called_with('Ethernet0', [0, 3], 3)
 
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=0))
+    @patch('sfputil.main.eeprom_dump_general')
+    def test_eeprom_hexdump_pages_general_continues_on_single_page_failure(self, mock_eeprom_dump_general):
+        """When one page read fails, dump continues and returns 0 with failure line in output."""
+        # Call 1: Lower page 0h success, Call 2: Upper page 0h fail, Call 3: Upper page 1h success
+        mock_eeprom_dump_general.side_effect = [
+            (0, "        00000000 00 01 02 03 ..."),
+            (1, "read error"),
+            (0, "        00000080 10 11 12 13 ..."),
+        ]
+        rc, output = sfputil.eeprom_hexdump_pages_general("Ethernet0", [0, 1], None)
+        assert rc == 0
+        assert "Lower page 0h" in output
+        assert "00000000 00 01 02 03" in output
+        assert "read error" in output
+        assert "Upper page 1h" in output
+        assert "00000080 10 11 12 13" in output
 
+    @patch('sfputil.main.platform_chassis')
+    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=0))
+    @patch('sfputil.main.eeprom_dump_general')
+    def test_eeprom_hexdump_pages_sff8472_continues_on_single_page_failure(self, mock_eeprom_dump_general, mock_chassis):
+        """When one SFF8472 page (e.g. A2h lower) fails, dump continues and returns 0."""
+        mock_api = MagicMock()
+        mock_api.is_flat_memory.return_value = False
+        mock_chassis.get_sfp.return_value.get_xcvr_api.return_value = mock_api
+        # A0h success, A2h lower fail, A2h upper success
+        mock_eeprom_dump_general.side_effect = [
+            (0, "        00000000 03 04 07 ..."),
+            (1, "A2h lower read error"),
+            (0, "        00000100 00 00 00 ..."),
+        ]
+        rc, output = sfputil.eeprom_hexdump_pages_sff8472("Ethernet0", [0, 1, 2], None)
+        assert rc == 0
+        assert "A0h dump" in output
+        assert "00000000 03 04 07" in output
+        assert "A2h lower read error" in output
+        assert "A2h dump (upper 128 bytes) page 0h" in output
+        assert "00000100 00 00 00" in output
 
     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=1))
     @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=True))
@@ -1584,40 +1618,40 @@ EEPROM hexdump for port Ethernet4
 
         mock_sfp.get_presence = MagicMock(return_value=True)
         mock_sfp.get_xcvr_api = MagicMock(return_value=api)
-        
+
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '-1', '-o', '0', '-d', '01'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '256', '-o', '0', '-d', '01'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '0', '-o', '-1', '-d', '01'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '0', '-o', '256', '-d', '01'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '1', '-o', '127', '-d', '01'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '1', '-o', '256', '-d', '01'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '-n', '0', '-o', '0', '-s', '0'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '-n', '0', '-o', '0', '-s', '257'])
         assert result.exit_code != 0
-        
+
         result = runner.invoke(sfputil.cli.commands['write-eeprom'],
                                ['-p', "Ethernet0", '-n', '0', '-o', '1', '-d', '01'])
         assert result.exit_code == 0
@@ -1635,13 +1669,13 @@ EEPROM hexdump for port Ethernet4
 
         mock_sfp.get_presence = MagicMock(return_value=True)
         mock_sfp.get_xcvr_api = MagicMock(return_value=api)
-        
+
         runner = CliRunner()
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '-n', '0', '-o', '0', '-s', '1'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'invalid', '-n', '0', '-o', '0', '-s', '1'])
         assert result.exit_code != 0
@@ -1656,49 +1690,49 @@ EEPROM hexdump for port Ethernet4
                                ['-p', "Ethernet0", '--wire-addr', 'A0h', '-n', '0', '-o', '-1', '-s', '1'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'A0h', '-n', '0', '-o', '256', '-s', '1'])
         assert result.exit_code != 0
         print(result.output)
 
-        result = runner.invoke(sfputil.cli.commands['read-eeprom'], 
+        result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'A0h', '-n', '0', '-o', '0', '-s', '0'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'A0h', '-n', '0', '-o', '0', '-s', '257'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         assert sfputil.get_overall_offset_sff8472(api, 0, 2, 2, wire_addr='A0h') == 2
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'a2h', '-n', '-1', '-o', '0', '-s', '1'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'a2h', '-n', '256', '-o', '0', '-s', '1'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'a2h', '-n', '0', '-o', '-1', '-s', '1'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'a2h', '-n', '0', '-o', '0', '-s', '0'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         result = runner.invoke(sfputil.cli.commands['read-eeprom'],
                                ['-p', "Ethernet0", '--wire-addr', 'a2h', '-n', '0', '-o', '0', '-s', '257'])
         assert result.exit_code != 0
         print(result.output)
-        
+
         assert sfputil.get_overall_offset_sff8472(api, 0, 2, 2, wire_addr='A2h') == 258
 
     @patch('sfputil.main.platform_chassis')


### PR DESCRIPTION
When a single EEPROM page fails to read during `sfputil show eeprom-hexdump`, the command no longer aborts. It continues dumping the remaining pages and returns success (exit 0), with the failed page’s error message included in the output.

#### What I did
- **Bug**: On some modules (e.g. CPO), `sfputil show eeprom-hexdump` failed with "Failed to read EEPROM for page 10h" for all modules and exited with an error, so no EEPROM data was shown and techsupport dumps did not contain `dump/interface.xcvrs.eeprom.RAW`. Because currently CPO didn't have page 10h yet.
- **Fix**: Treat a single-page read failure as non-fatal: append the error line to the output and continue with the next pages. The command still exits 0 so techsupport and scripts get a full/ partial dump.
 
#### How I did it
- **sfputil/main.py**
  - `eeprom_hexdump_pages_general()`: Removed early `return return_code, output` on page read failure. Always append `output` and continue, then return `(0, '\n'.join(lines))`.
  - `eeprom_hexdump_pages_sff8472()`: Same behavior for SFF8472 (A0h / A2h pages): no early return on failure, append output and continue.
- **tests/sfputil_test.py**
  - `test_eeprom_hexdump_all_falure`: Updated to expect exit 0 and that both ports’ headers and error messages appear in output (continue-on-failure behavior).
  - Added `test_eeprom_hexdump_pages_general_continues_on_single_page_failure`: one page fails, others succeed, asserts rc == 0 and output contains both error and successful page content.
  - Added `test_eeprom_hexdump_pages_sff8472_continues_on_single_page_failure`: same for SFF8472 (A0h ok, A2h lower fail, A2h upper ok).
 
#### How to verify it
- Unit tests: new and updated tests in `tests/sfputil_test.py` for continue-on-single-page-failure behavior.
- Manual: `sfputil show eeprom-hexdump` and `show techsupport` on CPO modules to confirm partial EEPROM dump and presence of `interface.xcvrs.eeprom.RAW`.
On EEPROM page read failure, log which page failed and continue dumping other pages instead of returning. Fixes modules where e.g. page 10h fails but other pages are readable. Allows techsupport dumps to include interface.xcvrs.eeprom.RAW.
